### PR TITLE
Blog app: add API endpoints

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -51,6 +51,8 @@ Lint/ScriptPermission:
   Enabled: false
 Lint/StructNewOverride:
   Enabled: false
+Lint/DuplicateBranch:
+  Enabled: false
 Style/HashEachMethods:
   Enabled: false
 Style/HashTransformKeys:

--- a/Gemfile
+++ b/Gemfile
@@ -56,6 +56,10 @@ gem 'bootsnap', require: false
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 # gem "image_processing", "~> 1.2"
 
+gem 'devise-jwt'
+
+gem 'rack-cors'
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem 'capybara'

--- a/Gemfile
+++ b/Gemfile
@@ -56,9 +56,9 @@ gem 'bootsnap', require: false
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 # gem "image_processing", "~> 1.2"
 
-gem 'devise-jwt'
+gem 'jwt'
 
-gem 'rack-cors'
+gem 'bcrypt'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile
+++ b/Gemfile
@@ -56,11 +56,6 @@ gem 'bootsnap', require: false
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 # gem "image_processing", "~> 1.2"
 
-# Use Json Web Token (JWT) for token based authentication
-gem 'jwt'
-# Use ActiveModel has_secure_password
-gem 'bcrypt', '~> 3.1.7'
-
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem 'capybara'

--- a/Gemfile
+++ b/Gemfile
@@ -56,6 +56,11 @@ gem 'bootsnap', require: false
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 # gem "image_processing", "~> 1.2"
 
+# Use Json Web Token (JWT) for token based authentication
+gem 'jwt'
+# Use ActiveModel has_secure_password
+gem 'bcrypt', '~> 3.1.7'
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem 'capybara'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -116,6 +116,7 @@ GEM
     jbuilder (2.11.5)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
+    jwt (2.3.0)
     launchy (2.5.0)
       addressable (~> 2.7)
     letter_opener (1.8.1)
@@ -276,6 +277,7 @@ PLATFORMS
   x64-mingw-ucrt
 
 DEPENDENCIES
+  bcrypt (~> 3.1.7)
   bootsnap
   bullet
   cancancan
@@ -285,6 +287,7 @@ DEPENDENCIES
   ffi
   importmap-rails
   jbuilder
+  jwt
   letter_opener
   pg (~> 1.1)
   puma (~> 5.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -99,8 +99,21 @@ GEM
       railties (>= 4.1.0)
       responders
       warden (~> 1.2.3)
+    devise-jwt (0.9.0)
+      devise (~> 4.0)
+      warden-jwt_auth (~> 0.6)
     diff-lcs (1.5.0)
     digest (3.1.0)
+    dry-auto_inject (0.9.0)
+      dry-container (>= 0.3.4)
+    dry-configurable (0.15.0)
+      concurrent-ruby (~> 1.0)
+      dry-core (~> 0.6)
+    dry-container (0.9.0)
+      concurrent-ruby (~> 1.0)
+      dry-configurable (~> 0.13, >= 0.13.0)
+    dry-core (0.7.1)
+      concurrent-ruby (~> 1.0)
     erubi (1.10.0)
     ffi (1.15.5-x64-mingw-ucrt)
     globalid (1.0.0)
@@ -116,6 +129,7 @@ GEM
     jbuilder (2.11.5)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
+    jwt (2.3.0)
     launchy (2.5.0)
       addressable (~> 2.7)
     letter_opener (1.8.1)
@@ -158,6 +172,8 @@ GEM
       nio4r (~> 2.0)
     racc (1.6.0)
     rack (2.2.3)
+    rack-cors (1.1.1)
+      rack (>= 2.0.0)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rails (7.0.2.3)
@@ -256,6 +272,11 @@ GEM
     uniform_notifier (1.16.0)
     warden (1.2.9)
       rack (>= 2.0.9)
+    warden-jwt_auth (0.6.0)
+      dry-auto_inject (~> 0.8)
+      dry-configurable (~> 0.13)
+      jwt (~> 2.1)
+      warden (~> 1.2)
     web-console (4.2.0)
       actionview (>= 6.0.0)
       activemodel (>= 6.0.0)
@@ -282,12 +303,14 @@ DEPENDENCIES
   capybara
   debug
   devise
+  devise-jwt
   ffi
   importmap-rails
   jbuilder
   letter_opener
   pg (~> 1.1)
   puma (~> 5.0)
+  rack-cors
   rails (~> 7.0.2, >= 7.0.2.3)
   rails-controller-testing
   rspec-rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -116,7 +116,6 @@ GEM
     jbuilder (2.11.5)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
-    jwt (2.3.0)
     launchy (2.5.0)
       addressable (~> 2.7)
     letter_opener (1.8.1)
@@ -277,7 +276,6 @@ PLATFORMS
   x64-mingw-ucrt
 
 DEPENDENCIES
-  bcrypt (~> 3.1.7)
   bootsnap
   bullet
   cancancan
@@ -287,7 +285,6 @@ DEPENDENCIES
   ffi
   importmap-rails
   jbuilder
-  jwt
   letter_opener
   pg (~> 1.1)
   puma (~> 5.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -99,21 +99,8 @@ GEM
       railties (>= 4.1.0)
       responders
       warden (~> 1.2.3)
-    devise-jwt (0.9.0)
-      devise (~> 4.0)
-      warden-jwt_auth (~> 0.6)
     diff-lcs (1.5.0)
     digest (3.1.0)
-    dry-auto_inject (0.9.0)
-      dry-container (>= 0.3.4)
-    dry-configurable (0.15.0)
-      concurrent-ruby (~> 1.0)
-      dry-core (~> 0.6)
-    dry-container (0.9.0)
-      concurrent-ruby (~> 1.0)
-      dry-configurable (~> 0.13, >= 0.13.0)
-    dry-core (0.7.1)
-      concurrent-ruby (~> 1.0)
     erubi (1.10.0)
     ffi (1.15.5-x64-mingw-ucrt)
     globalid (1.0.0)
@@ -172,8 +159,6 @@ GEM
       nio4r (~> 2.0)
     racc (1.6.0)
     rack (2.2.3)
-    rack-cors (1.1.1)
-      rack (>= 2.0.0)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rails (7.0.2.3)
@@ -272,11 +257,6 @@ GEM
     uniform_notifier (1.16.0)
     warden (1.2.9)
       rack (>= 2.0.9)
-    warden-jwt_auth (0.6.0)
-      dry-auto_inject (~> 0.8)
-      dry-configurable (~> 0.13)
-      jwt (~> 2.1)
-      warden (~> 1.2)
     web-console (4.2.0)
       actionview (>= 6.0.0)
       activemodel (>= 6.0.0)
@@ -297,20 +277,20 @@ PLATFORMS
   x64-mingw-ucrt
 
 DEPENDENCIES
+  bcrypt
   bootsnap
   bullet
   cancancan
   capybara
   debug
   devise
-  devise-jwt
   ffi
   importmap-rails
   jbuilder
+  jwt
   letter_opener
   pg (~> 1.1)
   puma (~> 5.0)
-  rack-cors
   rails (~> 7.0.2, >= 7.0.2.3)
   rails-controller-testing
   rspec-rails

--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -1,0 +1,7 @@
+class Api::V1::BaseController < ActionController::API
+  rescue_from ActiveRecord::RecordNotFound, with: :not_found
+
+  def not_found
+    render json: 'Bad request!', errors: 'Not Found', status: 404
+  end
+end

--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -4,4 +4,17 @@ class Api::V1::BaseController < ActionController::API
   def not_found
     render json: 'Bad request!', errors: 'Not Found', status: 404
   end
+
+  def authorize_request
+    header = request.headers['Authorization']
+    header = header.split(' ').last if header
+    begin
+      @decoded = JsonWebToken.decode(header)
+      @current_user = User.find(@decoded[:user_id])
+    rescue ActiveRecord::RecordNotFound => e
+      render json: { errors: e.message }, status: :unauthorized
+    rescue JWT::DecodeError => e
+      render json: { errors: e.message }, status: :unauthorized
+    end
+  end
 end

--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -1,13 +1,11 @@
 class Api::V1::BaseController < ActionController::API
-  rescue_from ActiveRecord::RecordNotFound, with: :not_found
-
   def not_found
-    render json: 'Bad request!', errors: 'Not Found', status: 404
+    render json: { error: 'not_found' }
   end
 
   def authorize_request
     header = request.headers['Authorization']
-    header = header.split(' ').last if header
+    header = header.split.last if header
     begin
       @decoded = JsonWebToken.decode(header)
       @current_user = User.find(@decoded[:user_id])

--- a/app/controllers/api/v1/comments_controller.rb
+++ b/app/controllers/api/v1/comments_controller.rb
@@ -1,0 +1,26 @@
+class Api::V1::CommentsController < Api::V1::BaseController
+  def index
+    @comments = Comment.where(post_id: params[:post_id])
+    render json: @comments
+  end
+
+  def create
+    @comment = Comment.new(comment_params)
+
+    if @comment.save
+      render json: @comment, status: 201
+    else
+      render json: "Comment is not created! User with id #{params[:user_id]} is not authorized to create comments!",
+             status: 401
+    end
+  end
+
+  private
+
+  def comment_params
+    comment_hash = params.require(:comment).permit(:text)
+    comment_hash[:author] = User.find(params[:user_id])
+    comment_hash[:post] = Post.find(params[:post_id])
+    comment_hash
+  end
+end

--- a/app/controllers/api/v1/comments_controller.rb
+++ b/app/controllers/api/v1/comments_controller.rb
@@ -11,7 +11,7 @@ class Api::V1::CommentsController < Api::V1::BaseController
     text = params[:text]
     post_id = params[:post_id]
 
-    @comment = Comment.new(author_id: user_id, post_id: post_id, text: text)
+    @comment = Comment.new(author_id: user_id, post_id:, text:)
 
     if @comment.save
       render json: @comment, status: 201

--- a/app/controllers/api/v1/comments_controller.rb
+++ b/app/controllers/api/v1/comments_controller.rb
@@ -1,11 +1,17 @@
 class Api::V1::CommentsController < Api::V1::BaseController
+  before_action :authorize_request
+
   def index
     @comments = Comment.where(post_id: params[:post_id])
     render json: @comments
   end
 
   def create
-    @comment = Comment.new(comment_params)
+    user_id = current_user.id
+    text = params[:text]
+    post_id = params[:post_id]
+
+    @comment = Comment.new(author_id: user_id, post_id: post_id, text: text)
 
     if @comment.save
       render json: @comment, status: 201
@@ -15,12 +21,10 @@ class Api::V1::CommentsController < Api::V1::BaseController
     end
   end
 
-  private
-
-  def comment_params
-    comment_hash = params.require(:comment).permit(:text)
-    comment_hash[:author] = User.find(params[:user_id])
-    comment_hash[:post] = Post.find(params[:post_id])
-    comment_hash
-  end
+  # def comment_params
+  #   comment_hash = params.require(:comment).permit(:text)
+  #   comment_hash[:author] = current_user.id
+  #   comment_hash[:post] = Post.find(params[:post_id])
+  #   comment_hash
+  # end
 end

--- a/app/controllers/api/v1/posts_controller.rb
+++ b/app/controllers/api/v1/posts_controller.rb
@@ -1,0 +1,7 @@
+class Api::V1::PostsController < Api::V1::BaseController
+  def index
+    @user = User.find(params[:user_id])
+    @posts = Post.where(author_id: @user.id)
+    render json: @posts
+  end
+end

--- a/app/controllers/api/v1/posts_controller.rb
+++ b/app/controllers/api/v1/posts_controller.rb
@@ -1,4 +1,6 @@
 class Api::V1::PostsController < Api::V1::BaseController
+  before_action :authorize_request
+  
   def index
     @user = User.find(params[:user_id])
     @posts = Post.where(author_id: @user.id)

--- a/app/controllers/api/v1/posts_controller.rb
+++ b/app/controllers/api/v1/posts_controller.rb
@@ -1,6 +1,6 @@
 class Api::V1::PostsController < Api::V1::BaseController
   before_action :authorize_request
-  
+
   def index
     @user = User.find(params[:user_id])
     @posts = Post.where(author_id: @user.id)

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -1,0 +1,11 @@
+class Api::V1::UsersController < Api::V1::BaseController
+  def index
+    render json: User.all
+  end
+
+  def show
+    @user = User.find(params[:id])
+
+    render json: @user, status: 200
+  end
+end

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -1,18 +1,5 @@
 class Api::V1::UsersController < Api::V1::BaseController
-  before_action :authorize_request, except: :create
-  before_action :find_user, except: %i[create index]
-
-  # def login
-  #   @user = User.find_by_email(params[:email])
-  #   if @user&.authenticate(params[:password])
-  #     token = JsonWebToken.encode(user_id: @user.id)
-  #     time = Time.now + 24.hours.to_i
-  #     render json: { token: token, exp: time.strftime("%m-%d-%Y %H:%M"),
-  #                    username: @user.username }, status: :ok
-  #   else
-  #     render json: { error: 'unauthorized' }, status: :unauthorized
-  #   end
-  # end
+  before_action :authorize_request
 
   def index
     render json: User.all

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -1,4 +1,19 @@
 class Api::V1::UsersController < Api::V1::BaseController
+  before_action :authorize_request, except: :create
+  before_action :find_user, except: %i[create index]
+
+  # def login
+  #   @user = User.find_by_email(params[:email])
+  #   if @user&.authenticate(params[:password])
+  #     token = JsonWebToken.encode(user_id: @user.id)
+  #     time = Time.now + 24.hours.to_i
+  #     render json: { token: token, exp: time.strftime("%m-%d-%Y %H:%M"),
+  #                    username: @user.username }, status: :ok
+  #   else
+  #     render json: { error: 'unauthorized' }, status: :unauthorized
+  #   end
+  # end
+
   def index
     render json: User.all
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,5 @@
 class ApplicationController < ActionController::Base
+  protect_from_forgery with: :null_session
   add_flash_types :danger, :info, :warning, :success, :messages
 
   protect_from_forgery with: :exception

--- a/app/controllers/authentication_controller.rb
+++ b/app/controllers/authentication_controller.rb
@@ -1,0 +1,23 @@
+class AuthenticationController < ApplicationController
+  protect_from_forgery with: :null_session
+  before_action :authorize_request, except: :login
+
+  # POST /auth/login
+  def login
+    @user = User.find_by_email(params[:email])
+    if Password.new(@user.encrypted_password) == params[:password]
+      token = JsonWebToken.encode(user_id: @user.id)
+      time = Time.now + 24.hours.to_i
+      render json: { token: token, exp: time.strftime("%m-%d-%Y %H:%M"),
+                     username: @user.username }, status: :ok
+    else
+      render json: { error: 'unauthorized' }, status: :unauthorized
+    end
+  end
+
+  private
+
+  def login_params
+    params.permit(:email, :password)
+  end
+end

--- a/app/controllers/authentication_controller.rb
+++ b/app/controllers/authentication_controller.rb
@@ -1,6 +1,8 @@
 class AuthenticationController < ApplicationController
+  include BCrypt
   protect_from_forgery with: :null_session
   before_action :authorize_request, except: :login
+
 
   # POST /auth/login
   def login
@@ -8,7 +10,7 @@ class AuthenticationController < ApplicationController
     if Password.new(@user.encrypted_password) == params[:password]
       token = JsonWebToken.encode(user_id: @user.id)
       time = Time.now + 24.hours.to_i
-      render json: { token: token, exp: time.strftime("%m-%d-%Y %H:%M"),
+      render json: { token:, exp: time.strftime('%m-%d-%Y %H:%M'),
                      username: @user.username }, status: :ok
     else
       render json: { error: 'unauthorized' }, status: :unauthorized

--- a/app/controllers/authentication_controller.rb
+++ b/app/controllers/authentication_controller.rb
@@ -3,7 +3,6 @@ class AuthenticationController < ApplicationController
   protect_from_forgery with: :null_session
   before_action :authorize_request, except: :login
 
-
   # POST /auth/login
   def login
     @user = User.find_by_email(params[:email])

--- a/app/lib/json_web_token.rb
+++ b/app/lib/json_web_token.rb
@@ -1,0 +1,13 @@
+class JsonWebToken
+  SECRET_KEY = Rails.application.secrets.secret_key_base. to_s
+
+  def self.encode(payload, exp = 24.hours.from_now)
+    payload[:exp] = exp.to_i
+    JWT.encode(payload, SECRET_KEY)
+  end
+
+  def self.decode(token)
+    decoded = JWT.decode(token, SECRET_KEY)[0]
+    HashWithIndifferentAccess.new decoded
+  end
+end

--- a/app/lib/json_web_token.rb
+++ b/app/lib/json_web_token.rb
@@ -1,5 +1,5 @@
 class JsonWebToken
-  SECRET_KEY = Rails.application.secrets.secret_key_base. to_s
+  SECRET_KEY = Rails.application.secrets.secret_key_base.to_s
 
   def self.encode(payload, exp = 24.hours.from_now)
     payload[:exp] = exp.to_i

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,7 +11,7 @@ Rails.application.routes.draw do
   root 'users#index'
 
   # api
-  namespace :api, defaults: {format: 'json'} do
+  namespace :api, defaults: { format: 'json' } do
     namespace :v1 do
       resources :users, only: %i[index show] do
         resources :posts, only: %i[index] do
@@ -20,4 +20,7 @@ Rails.application.routes.draw do
       end
     end
   end
+  
+  post 'auth/login', to: 'authentication#login'
+
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,13 +10,12 @@ Rails.application.routes.draw do
   # Defines the root path route ("/")
   root 'users#index'
 
-  #api
+  # api
   namespace :api, defaults: {format: 'json'} do
     namespace :v1 do
       resources :users, only: %i[index show] do
         resources :posts, only: %i[index] do
-          resources :comments, only: %i[index create] do
-          end
+          resources :comments, only: %i[index create]
         end
       end
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,7 +20,6 @@ Rails.application.routes.draw do
       end
     end
   end
-  
-  post 'auth/login', to: 'authentication#login'
 
+  post 'auth/login', to: 'authentication#login'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,4 +9,16 @@ Rails.application.routes.draw do
 
   # Defines the root path route ("/")
   root 'users#index'
+
+  #api
+  namespace :api, defaults: {format: 'json'} do
+    namespace :v1 do
+      resources :users, only: %i[index show] do
+        resources :posts, only: %i[index] do
+          resources :comments, only: %i[index create] do
+          end
+        end
+      end
+    end
+  end
 end

--- a/lib/json_web_token.rb
+++ b/lib/json_web_token.rb
@@ -1,0 +1,13 @@
+class JsonWebToken
+  SECRET_KEY = Rails.application.secrets.secret_key_base. to_s
+
+  def self.encode(payload, exp = 24.hours.from_now)
+    payload[:exp] = exp.to_i
+    JWT.encode(payload, SECRET_KEY)
+  end
+
+  def self.decode(token)
+    decoded = JWT.decode(token, SECRET_KEY)[0]
+    HashWithIndifferentAccess.new decoded
+  end
+end

--- a/lib/json_web_token.rb
+++ b/lib/json_web_token.rb
@@ -1,5 +1,5 @@
 class JsonWebToken
-  SECRET_KEY = Rails.application.secrets.secret_key_base. to_s
+  SECRET_KEY = Rails.application.secrets.secret_key_base.to_s
 
   def self.encode(payload, exp = 24.hours.from_now)
     payload[:exp] = exp.to_i


### PR DESCRIPTION
In this project, we added some API endpoints to the Blog app with propper authentication.

In order to authenticate, a user must exist, and then the following requests are possible:

**POST:**
`localhost:3000/auth/login`
with Body in form-data, using Keys: email and password.

That will return JSON data similar to:
```
{
    "token": "eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoyLCJleHAiOjE2NTI0ODIxODh9.zRVRrhm7wZNiE1BLtgwIcEbpEXhGcUSj0xrOU0wrSIU",
    "exp": "05-13-2022 18:49",
    "username": "susanne"
}
```

The token received needs to be used in a Authorization Key in the HEADER, whenever trying any of the following requests:

**GET:**
`localhost:3000/api/v1/users/` → list all posts for a user.
`localhost:3000/api/v1/users/user_id/posts/post_id/comments` → list all comments for a user's post.

**POST:**
`localhost:3000/api/v1/users/user_id/posts/post_id/comments` → add a comment to a post
Requires a JSON Body
`{ "text": "comment text" }`
